### PR TITLE
Add methods to keep hDAO balances updated

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -11,14 +11,14 @@ const client = new MongoClient(url)
 // method to populate the DB with all owners via upsert. Takes around 60 mins (500k records).
 const getOwners = async(arr,counter,owners) => {
   /*
-  https://staging.api.tzkt.io/v1/bigmaps/522/keys?sort.desc=id&select=key,value&offset=0&limit=10
+  https://api.tzkt.io/v1/bigmaps/522/keys?sort.desc=id&select=key,value&offset=0&limit=10
   limit can be up to 1000
   [{"key":{"nat":"68596","address":"tz1d7i7nUREze4LCpfonUeaJgdfhcWnoy7p9"},"value":"1"},..]
   
   owners collection: {"token_id": 999999, "owner_id": "tz123", "balance": 0 }
   unique index on token_id, owner_id. Index on owner_id for search.
   */
-  let res = await axios.get("https://staging.api.tzkt.io/v1/bigmaps/511/keys?sort.desc=id&select=key,value&limit=50&offset=" + counter)
+  let res = await axios.get("https://api.tzkt.io/v1/bigmaps/511/keys?sort.desc=id&select=key,value&limit=50&offset=" + counter)
     .then(res => res.data)
   res = await res.map(async e => {
 

--- a/handler.js
+++ b/handler.js
@@ -140,7 +140,9 @@ const getFeed = async (arr, counter, objkts) => {
 
   // gets latest objkts
 
-  let res = await axios.get("https://api.better-call.dev/v1/contract/mainnet/KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton/tokens?offset=" + counter).then(res => res.data)
+  let res = await axios
+    .get("https://api.better-call.dev/v1/contract/mainnet/KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton/tokens?offset=" + counter)
+    .then(res => res.data)
 
   res = await res.map(async e => {
 


### PR DESCRIPTION
The PR keeps hDAO balances updated and also::
* changes the URLs from tzkt.io to remove the `staging` subdomain now that the bigmap queries are now live
* changes the table that royalties are stored in to `metadata` to reduce the joins and/or number of queries made to the DB
